### PR TITLE
Replace use of deprecated constants

### DIFF
--- a/custom_components/deskbike/config_flow.py
+++ b/custom_components/deskbike/config_flow.py
@@ -5,7 +5,6 @@ import logging
 from typing import Any
 
 import voluptuous as vol
-from bleak import BleakScanner
 from homeassistant import config_entries
 from homeassistant.components.bluetooth import (
     BluetoothServiceInfoBleak,

--- a/custom_components/deskbike/device.py
+++ b/custom_components/deskbike/device.py
@@ -6,24 +6,23 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 from homeassistant.const import (
-    CONF_NAME,
     PERCENTAGE,
-    LENGTH_KILOMETERS,
-    SPEED_KILOMETERS_PER_HOUR,
+    UnitOfLength,
+    UnitOfSpeed,
 )
 
 SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="speed",
         name="Speed",
-        native_unit_of_measurement=SPEED_KILOMETERS_PER_HOUR,
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
         device_class=SensorDeviceClass.SPEED,
         icon="mdi:speedometer",
     ),
     SensorEntityDescription(
         key="distance",
         name="Distance",
-        native_unit_of_measurement=LENGTH_KILOMETERS,
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
         device_class=SensorDeviceClass.DISTANCE,
         icon="mdi:map-marker-distance",
     ),

--- a/custom_components/deskbike/number.py
+++ b/custom_components/deskbike/number.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 
 import logging
 from homeassistant.components.number import (
-    NumberEntity,
-    NumberEntityDescription,
     RestoreNumber,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import MASS_KILOGRAMS, CONF_NAME, CONF_ADDRESS
+from homeassistant.const import UnitOfMass, CONF_NAME, CONF_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -42,7 +40,7 @@ class DeskBikeWeightSetting(RestoreNumber):
         self._attr_native_max_value = 150
         self._attr_native_step = 0.5
         self._attr_mode = "slider"
-        self._attr_native_unit_of_measurement = MASS_KILOGRAMS
+        self._attr_native_unit_of_measurement = UnitOfMass.KILOGRAMS
         self._attr_name = "Weight"
         self._attr_entity_category = EntityCategory.CONFIG
         self._attr_icon = "mdi:weight"

--- a/custom_components/deskbike/sensor.py
+++ b/custom_components/deskbike/sensor.py
@@ -29,6 +29,7 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
+from homeassistant.helpers.storage import Store
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -408,11 +409,12 @@ class DeskBikeDataUpdateCoordinator(DataUpdateCoordinator):
                 self._daily_reset_time.isoformat()
             )
 
-            store = self.hass.helpers.storage.Store(
+            store = Store(
+                hass=self.hass,
                 version=1,
                 key=f"{DOMAIN}_persistent_data_{self.address}",
                 private=True,
-                atomic_writes=True
+                atomic_writes=True,
             )
             await store.async_save(persistent_data)
         except Exception as err:
@@ -421,7 +423,8 @@ class DeskBikeDataUpdateCoordinator(DataUpdateCoordinator):
     async def _restore_persistent_data(self) -> None:
         """Restore persistent sensor values including daily values."""
         try:
-            store = self.hass.helpers.storage.Store(
+            store = Store(
+                hass=self.hass,
                 version=1,
                 key=f"{DOMAIN}_persistent_data_{self.address}",
                 private=True
@@ -749,12 +752,12 @@ class DeskBikeDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _save_sensor_values(self):
         """Save sensor values to Home Assistant storage."""
-        store = self.hass.helpers.storage.Store(1, f"{DOMAIN}_sensor_values_{self.address}")
+        store = Store(self.hass, 1, f"{DOMAIN}_sensor_values_{self.address}")
         await store.async_save(self._data)
 
     async def _restore_sensor_values(self):
         """Restore sensor values from Home Assistant storage."""
-        store = self.hass.helpers.storage.Store(1, f"{DOMAIN}_sensor_values_{self.address}")
+        store = Store(self.hass, 1, f"{DOMAIN}_sensor_values_{self.address}")
         restored_data = await store.async_load()
         if restored_data:
             self._data.update(restored_data)

--- a/custom_components/deskbike/sensor.py
+++ b/custom_components/deskbike/sensor.py
@@ -19,9 +19,8 @@ from homeassistant.const import (
     CONF_ADDRESS,
     CONF_NAME,
     PERCENTAGE,
-    LENGTH_KILOMETERS,
-    SPEED_KILOMETERS_PER_HOUR,
-    TIME_SECONDS,
+    UnitOfLength,
+    UnitOfSpeed,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
@@ -58,7 +57,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="speed",
         name="Speed",
-        native_unit_of_measurement=SPEED_KILOMETERS_PER_HOUR,
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
         device_class=SensorDeviceClass.SPEED,
         icon="mdi:speedometer",
         state_class=SensorStateClass.MEASUREMENT,
@@ -66,7 +65,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="distance",
         name="Total Distance",
-        native_unit_of_measurement=LENGTH_KILOMETERS,
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
         device_class=SensorDeviceClass.DISTANCE,
         icon="mdi:map-marker-distance",
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -74,7 +73,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="daily_distance",
         name="Daily Distance",
-        native_unit_of_measurement=LENGTH_KILOMETERS,
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
         device_class=SensorDeviceClass.DISTANCE,
         icon="mdi:map-marker-distance",
         state_class=SensorStateClass.TOTAL_INCREASING,


### PR DESCRIPTION
Hi 👋! Thanks for this integration. I noticed some deprecated constant imports were used. See https://developers.home-assistant.io/blog/2022/10/26/new-unit-enumerators. As well as a deprecated way of using storage.Store